### PR TITLE
Migrate from prefabvalues mechanism to objenesis

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -13,7 +13,7 @@ test {
 
 dependencies {
     testImplementation project(":red-and-blue")
-    testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.17.1'
+    testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.19'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.4'

--- a/red-and-blue/build.gradle
+++ b/red-and-blue/build.gradle
@@ -85,7 +85,7 @@ test {
 configurations {
     configureEach {
         resolutionStrategy {
-            force 'nl.jqno.equalsverifier:equalsverifier:3.17.1'
+            force 'nl.jqno.equalsverifier:equalsverifier:3.19'
         }
     }
 }


### PR DESCRIPTION
This PR switches the supported EqualsVerifier version from 3.17 to 3.19+